### PR TITLE
Fix Bank#parse method

### DIFF
--- a/lib/latinum/bank.rb
+++ b/lib/latinum/bank.rb
@@ -105,10 +105,12 @@ module Latinum
 				Resource.new(parts[0].gsub(/[^\-\.0-9]/, ''), parts[1])
 			else
 				# Lookup the named symbol, e.g. '$', and get the highest priority name:
-				symbol = @symbols.fetch(string.gsub(/[\-\.,0-9]/, ''), []).last || default_name
+				symbol = @symbols.fetch(string.gsub(/[\-\.,0-9]/, ''), []).last
 				
 				if symbol
 					Resource.new(string.gsub(/[^\-\.0-9]/, ''), symbol.last.to_s)
+				elsif default_name
+					Resource.new(string.gsub(/[^\-\.0-9]/, ''), default_name.to_s)
 				else
 					raise ArgumentError.new("Could not parse #{string}, could not determine currency!")
 				end

--- a/lib/latinum/bank.rb
+++ b/lib/latinum/bank.rb
@@ -102,13 +102,13 @@ module Latinum
 			parts = string.strip.split(/\s+/, 2)
 			
 			if parts.size == 2
-				Resource.new(parts[0].gsub(/[^\.0-9]/, ''), parts[1])
+				Resource.new(parts[0].gsub(/[^\-\.0-9]/, ''), parts[1])
 			else
 				# Lookup the named symbol, e.g. '$', and get the highest priority name:
 				symbol = @symbols.fetch(string.gsub(/[\-\.,0-9]/, ''), []).last || default_name
 				
 				if symbol
-					Resource.new(string.gsub(/[^\.0-9]/, ''), symbol.last.to_s)
+					Resource.new(string.gsub(/[^\-\.0-9]/, ''), symbol.last.to_s)
 				else
 					raise ArgumentError.new("Could not parse #{string}, could not determine currency!")
 				end

--- a/spec/latinum/bank_spec.rb
+++ b/spec/latinum/bank_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe Latinum::Bank do
 		expect(@bank.parse("-$5")).to be == Latinum::Resource.new("-5", "USD")
 		expect(@bank.parse("-$5 NZD")).to be == Latinum::Resource.new("-5", "NZD")
 		expect(@bank.parse("-€5")).to be == Latinum::Resource.new("-5", "EUR")
+	
+		expect(@bank.parse("5", default_name: "EUR")).to be == Latinum::Resource.new("5", "EUR")
+		expect(@bank.parse("-5", default_name: "EUR")).to be == Latinum::Resource.new("-5", "EUR")
 	end
 	
 	it "should fail to parse unknown resource" do

--- a/spec/latinum/bank_spec.rb
+++ b/spec/latinum/bank_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Latinum::Bank do
 		expect(aud).to be == Latinum::Resource.new("5", "AUD")
 	end
 	
-	it "should parser strings into resources" do
+	it "should parse strings into resources" do
 		expect(@bank.parse("$5")).to be == Latinum::Resource.new("5", "USD")
 		expect(@bank.parse("$5 NZD")).to be == Latinum::Resource.new("5", "NZD")
 		expect(@bank.parse("€5")).to be == Latinum::Resource.new("5", "EUR")

--- a/spec/latinum/bank_spec.rb
+++ b/spec/latinum/bank_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe Latinum::Bank do
 		expect(@bank.parse("€5")).to be == Latinum::Resource.new("5", "EUR")
 		
 		expect(@bank.parse("5 NZD")).to be == Latinum::Resource.new("5", "NZD")
+	
+		expect(@bank.parse("-$5")).to be == Latinum::Resource.new("-5", "USD")
+		expect(@bank.parse("-$5 NZD")).to be == Latinum::Resource.new("-5", "NZD")
+		expect(@bank.parse("-€5")).to be == Latinum::Resource.new("-5", "EUR")
 	end
 	
 	it "should fail to parse unknown resource" do


### PR DESCRIPTION
Minor typo in the spec description.

Negative amounts weren't being parsed correctly because the negative sign was being removed. Fixed the regex and added some test coverage—maybe worth extracting the regex somewhere?

The default_name option wasn't working due to the `symbol.last` call. I'm assuming that option isn't *meant* to be an array (would be rather counter-intuitive).