### PR TITLE
DecimalCurrencyFormatter#format accept places option

### DIFF
--- a/lib/latinum/formatters.rb
+++ b/lib/latinum/formatters.rb
@@ -69,9 +69,9 @@ module Latinum
 			# Formats the amount using the configured symbol, separator, delimeter, and places.
 			# e.g. "$5,000.00 NZD". Rounds the amount to the specified number of decimal places.
 			# @returns [String] The formatted string.
-			def format(amount, **options)
+			def format(amount, places: @places, **options)
 				# Round to the desired number of places. Truncation used to be the default.
-				amount = amount.round(@places)
+				amount = amount.round(places)
 				
 				integral, fraction = amount.abs.to_s('F').split(/\./, 2)
 				
@@ -79,7 +79,7 @@ module Latinum
 				sign = '-' if amount < 0
 				
 				# Decimal places, e.g. the '.00' in '$10.00'
-				fraction = fraction[0...@places].ljust(@places, @zero)
+				fraction = fraction[0...places].ljust(places, @zero)
 				
 				# Grouping, e.g. the ',' in '$10,000.00'
 				remainder = integral.size % 3
@@ -92,7 +92,7 @@ module Latinum
 				name = options.fetch(:name, @name)
 				suffix = name ? " #{name}" : ''
 				
-				if @places > 0
+				if places > 0
 					"#{value}#{@separator}#{fraction}#{suffix}"
 				else
 					"#{value}#{suffix}"

--- a/spec/latinum/formatters_spec.rb
+++ b/spec/latinum/formatters_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe Latinum::Formatters::DecimalCurrencyFormatter do
 	it "should format output with alternative symbol" do
 		expect(@bank.format(resource, symbol: "!!")).to be == "!!10.00 NZD"
 	end
+
+	it "should format output with alternative places" do
+		expect(@bank.format(resource, places: 4)).to be == "$10.0000 NZD"
+	end
 	
 	context "negative zero" do
 		let(:resource) {Latinum::Resource.new(BigDecimal("-0"), "NZD")}


### PR DESCRIPTION
I'm not sure how I feel about this. Would you consider it an anti-pattern?

My use case is sub-cent billing (ala, cloud infrastructure that might bill $0.007 per hour). I'd like to format it with 3 decimal places but still round to 2.