### PR TITLE
Ensure rounded value is always BigDecimal

### DIFF
--- a/lib/latinum/formatters.rb
+++ b/lib/latinum/formatters.rb
@@ -71,7 +71,7 @@ module Latinum
 			# @returns [String] The formatted string.
 			def format(amount, places: @places, **options)
 				# Round to the desired number of places. Truncation used to be the default.
-				amount = amount.round(places)
+				amount = amount.round(places).to_d
 				
 				integral, fraction = amount.abs.to_s('F').split(/\./, 2)
 				


### PR DESCRIPTION
When `round` is called with `0`, it may return an `Integer`, which then we cannot call `to_s` on. I think we should just always ensure it's a `BigDecimal` after rounding.

Probably conflicts with #8. I'll rebase one or the other depending on the order of merging, if necessary.