### PR TITLE
Allow passing through existing Resource instance in `.load`.

### DIFF
--- a/lib/latinum/resource.rb
+++ b/lib/latinum/resource.rb
@@ -25,12 +25,16 @@ module Latinum
 		# Load a string representation of a resource.
 		# @parameter string [String | Nil] e.g. "5 NZD" or nil.
 		# @returns [Resource | Nil] The Resource that represents the parsed string.
-		def self.load(string)
-			if string
+		def self.load(input)
+			case input
+			when String
 				# Remove any whitespaces
-				string = string.strip
-				
-				parse(string) unless string.empty?
+				input = input.strip
+				parse(input) unless input.empty?
+			when Resource
+				input
+			else
+				nil
 			end
 		end
 		

--- a/test/latinum/resource.rb
+++ b/test/latinum/resource.rb
@@ -7,33 +7,42 @@
 require 'latinum/resource'
 
 describe Latinum::Resource do
-	it "should load and dump resources" do
-		resource = Latinum::Resource.load("10 NZD")
-		string_representation = Latinum::Resource.dump(resource)
+	with '.load and .dump' do
+		it "should load and dump resources" do
+			resource = Latinum::Resource.load("10 NZD")
+			string_representation = Latinum::Resource.dump(resource)
+			
+			loaded_resource = Latinum::Resource.load(string_representation)
+			
+			expect(loaded_resource).to be == loaded_resource
+		end
 		
-		loaded_resource = Latinum::Resource.load(string_representation)
+		it "should load and dump nil correctly" do
+			expect(Latinum::Resource.load(nil)).to be == nil
+			expect(Latinum::Resource.dump(nil)).to be == nil
+		end
 		
-		expect(loaded_resource).to be == loaded_resource
-	end
-	
-	it "should load and dump nil correctly" do
-		expect(Latinum::Resource.load(nil)).to be == nil
-		expect(Latinum::Resource.dump(nil)).to be == nil
-	end
-	
-	it "should handle empty strings correctly" do
-		expect(Latinum::Resource.load("")).to be == nil
-	end
-	
-	it "should handle whitespace strings correctly" do
-		expect(Latinum::Resource.load(" ")).to be == nil
-	end
-	
-	it "should load and dump resources correctly" do
-		resource = Latinum::Resource.new(10, 'NZD')
+		it "should handle empty strings correctly" do
+			expect(Latinum::Resource.load("")).to be == nil
+		end
 		
-		expect(Latinum::Resource.load("10.0 NZD")).to be == resource
-		expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
+		it "should handle whitespace strings correctly" do
+			expect(Latinum::Resource.load(" ")).to be == nil
+		end
+		
+		it "should load and dump resources correctly" do
+			resource = Latinum::Resource.new(10, 'NZD')
+			
+			expect(Latinum::Resource.load("10.0 NZD")).to be == resource
+			expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
+		end
+		
+		it "can pass through resources" do
+			resource = Latinum::Resource.new(10, 'NZD')
+			
+			expect(Latinum::Resource.load(resource)).to be == resource
+			expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
+		end
 	end
 	
 	it "should inspect nicely" do


### PR DESCRIPTION
As discussed in https://github.com/ioquatix/latinum/issues/12

Open question: is this the expected behaviour? How do other AR `serialize` implementations work?