### PR TITLE
Allow the bank to function as a coder.

### DIFF
--- a/lib/latinum/bank.rb
+++ b/lib/latinum/bank.rb
@@ -121,8 +121,11 @@ module Latinum
 			end
 		end
 		
-		def load(value)
-			parse(value) if value
+		def load(input)
+			if input.is_a?(String)
+				input = input.strip
+				return parse(input) unless input.empty?
+			end
 		end
 		
 		def dump(resource)

--- a/lib/latinum/bank.rb
+++ b/lib/latinum/bank.rb
@@ -121,6 +121,14 @@ module Latinum
 			end
 		end
 		
+		def load(value)
+			parse(value) if value
+		end
+		
+		def dump(resource)
+			resource.to_s if resource
+		end
+		
 		private def parse_named_resource(name, value)
 			if formatter = @formatters[name]
 				return Resource.new(formatter.parse(value), name)

--- a/lib/latinum/resource.rb
+++ b/lib/latinum/resource.rb
@@ -26,15 +26,9 @@ module Latinum
 		# @parameter string [String | Nil] e.g. "5 NZD" or nil.
 		# @returns [Resource | Nil] The Resource that represents the parsed string.
 		def self.load(input)
-			case input
-			when String
-				# Remove any whitespaces
+			if input.is_a?(String)
 				input = input.strip
-				parse(input) unless input.empty?
-			when Resource
-				input
-			else
-				nil
+				return parse(input) unless input.empty?
 			end
 		end
 		

--- a/lib/latinum/resource.rb
+++ b/lib/latinum/resource.rb
@@ -25,12 +25,16 @@ module Latinum
 		# Load a string representation of a resource.
 		# @parameter string [String | Nil] e.g. "5 NZD" or nil.
 		# @returns [Resource | Nil] The Resource that represents the parsed string.
-		def self.load(string)
-			if string
+		def self.load(input)
+			case input
+			when String
 				# Remove any whitespaces
-				string = string.strip
-				
-				parse(string) unless string.empty?
+				input = input.strip
+				parse(input) unless input.empty?
+			when Resource
+				input
+			else
+				nil
 			end
 		end
 		

--- a/test/latinum/bank.rb
+++ b/test/latinum/bank.rb
@@ -15,6 +15,37 @@ describe Latinum::Bank do
 		end
 	end
 	
+	with '.load and .dump' do
+		it "should load and dump resources" do
+			resource = Latinum::Resource.load("10 NZD")
+			string_representation = Latinum::Resource.dump(resource)
+			
+			loaded_resource = bank.load(string_representation)
+			
+			expect(loaded_resource).to be == loaded_resource
+		end
+		
+		it "should load and dump nil correctly" do
+			expect(bank.load(nil)).to be == nil
+			expect(bank.dump(nil)).to be == nil
+		end
+		
+		it "should handle empty strings correctly" do
+			expect(bank.load("")).to be == nil
+		end
+		
+		it "should handle whitespace strings correctly" do
+			expect(bank.load(" ")).to be == nil
+		end
+		
+		it "should load and dump resources correctly" do
+			resource = Latinum::Resource.new(10, 'NZD')
+			
+			expect(bank.load("10.0 NZD")).to be == resource
+			expect(bank.dump(resource)).to be == "10.0 NZD"
+		end
+	end
+	
 	it "should format the amounts correctly" do
 		resource = Latinum::Resource.new("10", "NZD")
 		

--- a/test/latinum/resource.rb
+++ b/test/latinum/resource.rb
@@ -36,13 +36,6 @@ describe Latinum::Resource do
 			expect(Latinum::Resource.load("10.0 NZD")).to be == resource
 			expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
 		end
-		
-		it "can pass through resources" do
-			resource = Latinum::Resource.new(10, 'NZD')
-			
-			expect(Latinum::Resource.load(resource)).to be == resource
-			expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
-		end
 	end
 	
 	it "should inspect nicely" do

--- a/test/latinum/resource.rb
+++ b/test/latinum/resource.rb
@@ -7,33 +7,42 @@
 require 'latinum/resource'
 
 describe Latinum::Resource do
-	it "should load and dump resources" do
-		resource = Latinum::Resource.load("10 NZD")
-		string_representation = Latinum::Resource.dump(resource)
+	with '.load and .dump' do
+		it "should load and dump resources" do
+			resource = Latinum::Resource.load("10 NZD")
+			string_representation = Latinum::Resource.dump(resource)
+			
+			loaded_resource = Latinum::Resource.load(string_representation)
+			
+			expect(loaded_resource).to be == loaded_resource
+		end
 		
-		loaded_resource = Latinum::Resource.load(string_representation)
+		it "should load and dump nil correctly" do
+			expect(Latinum::Resource.load(nil)).to be == nil
+			expect(Latinum::Resource.dump(nil)).to be == nil
+		end
 		
-		expect(loaded_resource).to be == loaded_resource
-	end
-	
-	it "should load and dump nil correctly" do
-		expect(Latinum::Resource.load(nil)).to be == nil
-		expect(Latinum::Resource.dump(nil)).to be == nil
-	end
-	
-	it "should handle empty strings correctly" do
-		expect(Latinum::Resource.load("")).to be == nil
-	end
-	
-	it "should handle whitespace strings correctly" do
-		expect(Latinum::Resource.load(" ")).to be == nil
-	end
-	
-	it "should load and dump resources correctly" do
-		resource = Latinum::Resource.new(10, 'NZD')
+		it "should handle empty strings correctly" do
+			expect(Latinum::Resource.load("")).to be == nil
+		end
 		
-		expect(Latinum::Resource.load("10.0 NZD")).to be == resource
-		expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
+		it "should handle whitespace strings correctly" do
+			expect(Latinum::Resource.load(" ")).to be == nil
+		end
+		
+		it "should load and dump resources correctly" do
+			resource = Latinum::Resource.new(10, 'NZD')
+			
+			expect(Latinum::Resource.load("10.0 NZD")).to be == resource
+			expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
+		end
+		
+		it "can pass through resources" do
+			resource = Latinum::Resource.new(10, 'NZD')
+			
+			expect(Latinum::Resource.load(resource)).to be == resource
+			expect(Latinum::Resource.dump(resource)).to be == "10.0 NZD"
+		end
 	end
 	
 	it "should inspect nicely" do


### PR DESCRIPTION
Allows a bank instance to function as a coder, which accepts more reasonable "human" formatted amounts:

https://github.com/ioquatix/latinum/issues/12

```ruby
require 'latinum/currencies/global'

class T < ApplicationRecord
  BANK = Latinum::Bank.new.tap do |bank|
    bank.import(Latinum::Currencies::Global)
  end
  
  serialize :amount, coder: BANK
end
```